### PR TITLE
Update the client to use a new modular syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 ## Standalone usage
 
 To use the client in standalone mode:
+
 ```
+bundle install
 export FLIGHT_SSO_TOKEN=....  # Your SSO token
 export FLIGHT_CACHE_HOST=...  # The domain to the app e.g. 'localhost:3000'
-bundle install
 rake console
 ```
 
@@ -36,6 +37,7 @@ the response to a model.
 ### Blobs Builder
 
 The blobs builder is returned by:
+
 ```
 > client.blobs
 => FlightCache::Models::Blob
@@ -116,5 +118,62 @@ details.
 > uploader.to_container(id:)    # container given by :id
 > uploader.to_tag(tag:)         # the users tagged container
 > uploader.to_tag(tag: scope:)  # the tagged container given by scope
+```
+
+### Container Builder
+
+The container builder can be returned by:
+```
+> client.containers
+=> FlightCache::Models::Container
+```
+
+#### Getting a Container
+
+Getting a single container by `:id` is equivalent in syntax to getting a blob:
+
+```
+> ctr = client.containers.get(id: 1)
+=> {
+ :id=>"1",
+ :tag=>..,
+ :__data__=> ...
+}
+> ctr.class
+=> FlightCache::Models::Container
+```
+
+A container can also be fetched by using a `:tag` and optional `:scope`:
+
+```
+Gets the container by tag that belongs to:
+> client.containers.get(tag:)         # the user
+> client.containers.get(tag:, scope:) # the object given by the scope
+```
+
+#### Listing Containers
+
+Listing containers can only (currently) be done by `:tag`
+
+```
+> client.containers.list(tag:)
+```
+
+#### Uploading to a Container
+
+Uploading is primarily handled by the `BlobBuilder` and thus the
+`ContainerBuilder` does not have an `upload` method.
+
+However it is possible to upload to a fetched container using the `upload`
+instance method. The following method calls are equivalent in end result
+but will differ in API requests:
+
+```
+# Upload directly using the BlobsBuilder
+> client.blobs.uploader(<uploader_args>).to_container(<get_args>)
+
+# First fetch the Container model and then upload to it
+# NOTE: This will make two requests
+> client.containers.get(<get_args>).upload(<uploader_args>)
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Blobs can also be filtered by tag by using the `list(tag:)` method. It will
 return all the blobs the user has access to; filtered by tag.
 
 ```
-> blobs = client.blobs.list(tag: <tag>)
+> blobs = client.blobs.list(tag:)
 => [<#FlightCache::Models::Blob:..>, ...]
 ```
 
@@ -73,7 +73,7 @@ This will list all the blobs in all the users containers of that type. The
 
 See below for a full discussion on the valid scope
 ```
-> client.blobs.list(tag: <tag>, scope: <scope>)
+> client.blobs.list(tag:, scope:)
 => [...] # Only return blobs with the specified tag and scope
 ```
 
@@ -96,6 +96,25 @@ the instance method:
 => ... # As above
 ```
 
-### Uploading
+#### Uploading
 
-There is an `upload` method on the client. See code for details.
+Uploading a blob is a two step process. Firstly, an `Uploader` struct needs to
+be created as an abstraction to the files details. It must be given the
+`:filename` and an `:io` containing the file data.
+
+```
+> uploader = client.blobs.uploader(filename:, io:)
+=> #<struct FlightCache::Models::Blob::Uploader:..>
+```
+
+Then the file is uploaded to a container either by `:id` or `:tag`. The `:scope`
+is optional when used with a `:tag`. See discussion about the `:scope` for more
+details.
+
+```
+# The following methods upload to:
+> uploader.to_container(id:)    # container given by :id
+> uploader.to_tag(tag:)         # the users tagged container
+> uploader.to_tag(tag: scope:)  # the tagged container given by scope
+```
+

--- a/Rakefile
+++ b/Rakefile
@@ -39,6 +39,7 @@ task console: :setup do
   require 'pry'
   require 'pry-byebug'
 
+  client = FlightCache::Client.new(ENV['FLIGHT_CACHE_HOST'], ENV['FLIGHT_SSO_TOKEN'])
   binding.pry
 end
 

--- a/flight_cache.gemspec
+++ b/flight_cache.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'faraday'
   spec.add_runtime_dependency 'faraday_middleware'
   spec.add_runtime_dependency 'hashie'

--- a/lib/flight_cache.rb
+++ b/lib/flight_cache.rb
@@ -25,20 +25,5 @@
 # ==============================================================================
 #
 
-task :setup do
-  $LOAD_PATH << File.join(__dir__, 'lib')
-  ENV['BUNDLE_GEMFILE'] ||= File.join(__dir__, 'Gemfile')
-
-  require 'rubygems'
-  require 'bundler/setup'
-
-  require 'flight_cache'
-end
-
-task console: :setup do
-  require 'pry'
-  require 'pry-byebug'
-
-  binding.pry
-end
-
+require 'flight_cache/client'
+require 'flight_cache/models'

--- a/lib/flight_cache/client.rb
+++ b/lib/flight_cache/client.rb
@@ -52,23 +52,20 @@ module FlightCache
     def initialize(host, token)
       @host = host
       @token = token
-      super(Models::Blob.builder(self))
     end
 
     def connection
-      @connection ||= begin
-        Faraday::Connection.new(host) do |conn|
-          conn.token_auth(token)
-          conn.request :json
+      Faraday::Connection.new(host) do |conn|
+        conn.token_auth(token)
+        conn.request :json
 
-          conn.use FaradayMiddleware::FollowRedirects
-          conn.use RaiseError
+        conn.use FaradayMiddleware::FollowRedirects
+        conn.use RaiseError
 
-          conn.use FaradayMiddleware::Mashify
-          conn.response :json, :content_type => /\bjson$/
+        conn.use FaradayMiddleware::Mashify
+        conn.response :json, :content_type => /\bjson$/
 
-          conn.adapter Faraday.default_adapter
-        end
+        conn.adapter Faraday.default_adapter
       end
     end
 
@@ -78,6 +75,14 @@ module FlightCache
 
     def token
       (v = @token).to_s.empty? ? (raise 'No token given'): v
+    end
+
+    def blobs
+      Models::Blob.builder(self)
+    end
+
+    def containers
+      Models::Container.builder(self)
     end
   end
 end

--- a/lib/flight_cache/client.rb
+++ b/lib/flight_cache/client.rb
@@ -30,7 +30,7 @@ require 'flight_cache/error'
 require 'flight_cache/models'
 
 module FlightCache
-  class Client < DelegateClass(Faraday::Connection)
+  class Client
     class RaiseError < Faraday::Response::RaiseError
       def call(req)
         @app.call(req).on_complete do |res|

--- a/lib/flight_cache/error.rb
+++ b/lib/flight_cache/error.rb
@@ -59,4 +59,8 @@ module FlightCache
   # BadRequestError
   # Use: The client could not make the request for some reason
   class BadRequestError < Error; end
+
+  # MissingBuilderError
+  # Use: A model can not make an additional request as it is mising its builder
+  class MissingBuilderError < Error; end
 end

--- a/lib/flight_cache/error.rb
+++ b/lib/flight_cache/error.rb
@@ -55,4 +55,8 @@ module FlightCache
   # ModelTypeError
   # Use: The server response does not match the model type
   class ModelTypeError < Error; end
+
+  # BadRequestError
+  # Use: The client could not make the request for some reason
+  class BadRequestError < Error; end
 end

--- a/lib/flight_cache/model.rb
+++ b/lib/flight_cache/model.rb
@@ -69,10 +69,10 @@ module FlightCache
       def data_to_model(data)
         unless data.type == self.class.api_type
           raise ModelTypeError, <<~ERROR.chomp
-            Was expecting a #{klass} but got #{model.class}
+            Was expecting a #{self.class.api_type} but got #{data.type}
           ERROR
         end
-        klass.new(__data__: data)
+        klass.new(__data__: data, __builder__: self)
       end
 
       def paths
@@ -124,6 +124,7 @@ module FlightCache
     # end
 
     property :__data__
+    property :__builder__
 
     def to_h
       super().dup.tap { |h| h.delete(:__data__) }
@@ -131,6 +132,15 @@ module FlightCache
 
     def data?
       !!__data__
+    end
+
+    private
+
+    def builder
+      return __builder__ if __builder__
+      raise MissingBuilderError, <<~ERROR.chomp
+        Can not make any additional requests as the 'builder' is missing
+      ERROR
     end
   end
 end

--- a/lib/flight_cache/model.rb
+++ b/lib/flight_cache/model.rb
@@ -26,6 +26,7 @@
 #
 
 require 'hashie'
+require 'flight_cache/path_helper'
 
 module FlightCache
   class Model < Hashie::Trash
@@ -57,6 +58,12 @@ module FlightCache
 
       def coerce_build
         super(yield(client.connection))
+      end
+
+      private
+
+      def paths
+        PathHelper.new
       end
     end
 

--- a/lib/flight_cache/models.rb
+++ b/lib/flight_cache/models.rb
@@ -27,22 +27,5 @@
 
 require 'flight_cache/model'
 
-module FlightCache
-  module Models
-    def self.coerce_build(data, klass: nil)
-      if data.is_a?(Array)
-        data.map { |d| coerce_build(d, klass: klass) }
-      else
-        const_get(data.type.capitalize).build(data).tap do |model|
-          next if klass.nil? || model.is_a?(klass)
-          raise ModelTypeError, <<~ERROR.chomp
-            Was expecting a #{klass} but got #{model.class}
-          ERROR
-        end
-      end
-    end
-  end
-end
-
 require 'flight_cache/models/blob'
 require 'flight_cache/models/container'

--- a/lib/flight_cache/models/blob.rb
+++ b/lib/flight_cache/models/blob.rb
@@ -31,18 +31,21 @@ module FlightCache
         def to_container(id:)
           path = container_upload_path(id)
           builder.build do |con|
-            res = con.post(path, io.read) do |req|
+            con.post(path, io.read) do |req|
               req.headers['Content-Type'] = 'application/octet-stream'
-            end
-            res.body.data
+            end.body.data
           end
+        end
+
+        def to_tag(tag:, scope: nil)
+          ctr = builder.client.containers.get(tag: tag, scope: scope)
+          to_container(id: ctr.id)
         end
 
         private
 
         def container_upload_path(container_id)
-          Container.builder(builder.client)
-                   .join(container_id, 'upload', filename)
+          builder.client.containers.join(container_id, 'upload', filename)
         end
       end
 

--- a/lib/flight_cache/models/blob.rb
+++ b/lib/flight_cache/models/blob.rb
@@ -56,9 +56,10 @@ module FlightCache
           end
         end
 
-        def list(tag:)
+        def list(tag:, scope: nil)
           coerce_build do |con|
-            con.get("/tags/#{tag}/blobs").body.data
+            con.get("/tags/#{tag}/blobs", scope: scope)
+               .body.data
           end
         end
 

--- a/lib/flight_cache/models/blob.rb
+++ b/lib/flight_cache/models/blob.rb
@@ -50,6 +50,7 @@ module FlightCache
       end
 
       builder_class do
+        api_type 'blob'
         api_name 'blobs'
 
         def get(id:)
@@ -59,7 +60,7 @@ module FlightCache
         end
 
         def list(tag:, scope: nil)
-          coerce_build do |c|
+          build_enum do |c|
             c.get(paths.tag(tag, 'blobs'), scope: scope).body.data
           end
         end

--- a/lib/flight_cache/models/blob.rb
+++ b/lib/flight_cache/models/blob.rb
@@ -78,6 +78,10 @@ module FlightCache
       data_attribute :checksum
       data_attribute :filename
       data_attribute :size, from: :byte_size
+
+      def download
+        builder.download(id: self.id)
+      end
     end
   end
 end

--- a/lib/flight_cache/models/blob.rb
+++ b/lib/flight_cache/models/blob.rb
@@ -57,9 +57,8 @@ module FlightCache
         end
 
         def list(tag:, scope: nil)
-          coerce_build do |con|
-            con.get("/tags/#{tag}/blobs", scope: scope)
-               .body.data
+          coerce_build do |c|
+            c.get("/tags/#{tag}/blobs", scope: scope).body.data
           end
         end
 

--- a/lib/flight_cache/models/blob.rb
+++ b/lib/flight_cache/models/blob.rb
@@ -29,8 +29,8 @@ module FlightCache
   module Models
     class Blob < Model
       Uploader = Struct.new(:builder, :filename, :io) do
-        def to_container(container_id)
-          path = container_upload_path(container_id)
+        def to_container(id:)
+          path = container_upload_path(id)
           builder.build do |con|
             res = con.post(path, io.read) do |req|
               req.headers['Content-Type'] = 'application/octet-stream'
@@ -50,7 +50,7 @@ module FlightCache
       builder_class do
         api_name 'blobs'
 
-        def get(id)
+        def get(id:)
           build do |con|
             con.get(join(id)).body.data
           end
@@ -62,12 +62,12 @@ module FlightCache
           end
         end
 
-        def download(id)
+        def download(id:)
           client.connection.get(join(id, 'download')).body
         end
 
-        def uploader(name, io)
-          Uploader.new(self, name, io)
+        def uploader(filename:, io:)
+          Uploader.new(self, filename, io)
         end
       end
 

--- a/lib/flight_cache/models/blob.rb
+++ b/lib/flight_cache/models/blob.rb
@@ -20,8 +20,7 @@
 # along with Flight Cache.  If not, see <http://www.gnu.org/licenses/>.
 #
 # For more information on the Flight Cache, please visit:
-# https://github.com/alces-software/flight-cache
-# https://github.com/alces-software/flight-cache-cli
+# https://github.com/alces-software/flight_cache
 # ==============================================================================
 #
 
@@ -58,7 +57,7 @@ module FlightCache
 
         def list(tag:, scope: nil)
           coerce_build do |c|
-            c.get("/tags/#{tag}/blobs", scope: scope).body.data
+            c.get(paths.tag(tag, 'blobs'), scope: scope).body.data
           end
         end
 

--- a/lib/flight_cache/models/container.rb
+++ b/lib/flight_cache/models/container.rb
@@ -31,6 +31,7 @@ module FlightCache
     class Container < Model
       builder_class do
         api_name 'containers'
+        api_type 'container'
 
         def get(id: nil, tag: nil, scope: nil)
           build do |c|
@@ -47,7 +48,7 @@ module FlightCache
         end
 
         def list(tag:)
-          coerce_build do |con|
+          build_enum do |con|
             con.get(paths.tag(tag)).body.data
           end
         end

--- a/lib/flight_cache/models/container.rb
+++ b/lib/flight_cache/models/container.rb
@@ -31,6 +31,12 @@ module FlightCache
       builder_class do
         api_name 'containers'
 
+        def get(id:)
+          build do |c|
+            c.get(join(id)).body.data
+          end
+        end
+
         def list(tag:)
           coerce_build do |con|
             con.get("/tags/#{tag}").body.data

--- a/lib/flight_cache/models/container.rb
+++ b/lib/flight_cache/models/container.rb
@@ -56,6 +56,10 @@ module FlightCache
 
       data_id
       data_attribute :tag
+
+      def upload(*a)
+        builder.client.blobs.uploader(*a).to_container(id: self.id)
+      end
     end
   end
 end

--- a/lib/flight_cache/path_helper.rb
+++ b/lib/flight_cache/path_helper.rb
@@ -24,37 +24,12 @@
 # ==============================================================================
 #
 
-require 'flight_cache/error'
 
 module FlightCache
-  module Models
-    class Container < Model
-      builder_class do
-        api_name 'containers'
-
-        def get(id: nil, tag: nil, scope: nil)
-          build do |c|
-            if id
-              c.get(join(id))
-            elsif tag
-              c.get(paths.tag(tag, 'container'), scope: scope)
-            else
-              raise BadRequestError, <<~ERROR.chomp
-                Please specify either the container :id or :tag
-              ERROR
-            end.body.data
-          end
-        end
-
-        def list(tag:)
-          coerce_build do |con|
-            con.get(paths.tag(tag)).body.data
-          end
-        end
-      end
-
-      data_id
-      data_attribute :tag
+  class PathHelper
+    def tag(tag_name, *parts)
+      ["tags", tag_name, *parts].join('/')
     end
   end
 end
+


### PR DESCRIPTION
The syntax surrounding the client has been updated to be modular in design. This is to allow other sub clients (aka the Container Builder) to be slotted into the client with ease.

Please refer to the README for full documentation concerning the change.