### PR TITLE
Return an IO from the download method

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,15 @@ If the metadata model has already been fetched, then it can be downloaded using
 the instance method:
 
 ```
-> client.blobs.download(1)
-=> <#String:..> # Maybe a hashie? This needs to be clarified
+> client.blobs.download(id:)
+=> <#IO:...>
+
+> client.blobs.download(id:) { |io| ... }
+=> # Result of the block
 
 # Downloading via a get
 # NOTE: This will perform two request
-> client.blobs.get(1).download
+> client.blobs.get(id:).download
 => ... # As above
 ```
 

--- a/lib/flight_cache/client.rb
+++ b/lib/flight_cache/client.rb
@@ -59,7 +59,6 @@ module FlightCache
         conn.token_auth(token)
         conn.request :json
 
-        conn.use FaradayMiddleware::FollowRedirects
         conn.use RaiseError
 
         conn.use FaradayMiddleware::Mashify

--- a/lib/flight_cache/models/blob.rb
+++ b/lib/flight_cache/models/blob.rb
@@ -24,6 +24,8 @@
 # ==============================================================================
 #
 
+require 'open-uri'
+
 module FlightCache
   module Models
     class Blob < Model
@@ -66,7 +68,7 @@ module FlightCache
         end
 
         def download(id:)
-          client.connection.get(join(id, 'download')).body
+          open(client.connection.get(join(id, 'download')).headers["location"])
         end
 
         def uploader(filename:, io:)

--- a/lib/flight_cache/models/blob.rb
+++ b/lib/flight_cache/models/blob.rb
@@ -67,8 +67,9 @@ module FlightCache
           end
         end
 
-        def download(id:)
-          open(client.connection.get(join(id, 'download')).headers["location"])
+        def download(id:, &b)
+          url = client.connection.get(join(id, 'download')).headers["location"]
+          open(url, &b)
         end
 
         def uploader(filename:, io:)

--- a/lib/flight_cache/version.rb
+++ b/lib/flight_cache/version.rb
@@ -26,5 +26,5 @@
 #
 
 module FlightCache
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
This allows the calling application to dictate where the file should be saved. It also makes it consistent with the `uploader` which also uses an IO.

This uses a combination of `Faraday` to make the API request and `open-uri` to follow the redirect to S3. This naturally returns an IO (either `StringIO` or `Tempfile` depending on the size).