### PR TITLE
Raise 404 errors as FlightCache::NotFoundError

### DIFF
--- a/lib/flight_cache.rb
+++ b/lib/flight_cache.rb
@@ -48,7 +48,7 @@ class FlightCache
   end
 
   def upload(name, io, tag:, scope: nil)
-    client.blobs.uploader(filname: name, io: io).to_tag(tag: tag, scope: scope)
+    client.blobs.uploader(filename: name, io: io).to_tag(tag: tag, scope: scope)
   end
 
   def download(id)

--- a/lib/flight_cache/client.rb
+++ b/lib/flight_cache/client.rb
@@ -39,6 +39,12 @@ class FlightCache
             raise UnauthorizedError, res.body&.error
           when 403
             raise ForbiddenError
+          when 404
+            if req.body.respond_to?(:error)
+              raise NotFoundError, req.body.error
+            else
+              raise NotFoundError
+            end
           else
             on_complete(req)
           end

--- a/lib/flight_cache/client.rb
+++ b/lib/flight_cache/client.rb
@@ -43,7 +43,7 @@ class FlightCache
             if req.body.respond_to?(:error)
               raise NotFoundError, req.body.error
             else
-              raise NotFoundError
+              on_complete(req)
             end
           else
             on_complete(req)

--- a/lib/flight_cache/error.rb
+++ b/lib/flight_cache/error.rb
@@ -37,8 +37,8 @@ class FlightCache
       You do not have permission to view this content
     ERROR
 
-    def initialize(raw = nil)
-      super((raw.nil? || raw.empty?) ? MESSAGE : raw)
+    def initialize(raw = MESSAGE)
+      super
     end
   end
 
@@ -51,6 +51,17 @@ class FlightCache
   # Use: Accessed denied due to lack of permissions
   # Code: 403
   class ForbiddenError < VerbotenError; end
+
+  # NotFoundError
+  # Use: The resource could not be located
+  # Code: 404
+  class NotFoundError < Error
+    MESSAGE = 'Resource not found'
+
+    def initialize(msg = MESSAGE)
+      super
+    end
+  end
 
   # ModelTypeError
   # Use: The server response does not match the model type


### PR DESCRIPTION
This is to allow for nicer error handling than the standard `404` response. The error is now a `FlightCache` error, which means it is safe for the user application to catch (as opposed to a `Faraday` error).

It also allows the server to set the error message, thus giving the user more information about what has gone wrong. This fixes #5 on the client end, however it does require a server update to get the error message correctly.

This change is backwards compatible, apart from the previously mentioned change in the error class