### PR TITLE
Correctly set the version number

### DIFF
--- a/lib/flight_cache/version.rb
+++ b/lib/flight_cache/version.rb
@@ -26,5 +26,5 @@
 #
 
 class FlightCache
-  VERSION = '0.5.0'
+  VERSION = '0.5.2'
 end


### PR DESCRIPTION
The 0.5.1 release did get its version bumped. It is being skipped to
0.5.2